### PR TITLE
feat: Désactivation de a publication automatique sur GitHub Packages

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,21 +57,6 @@ gradlePlugin {
 
 publishing {
     repositories {
-        val githubUser = System.getenv("githubUser")
-        val githubPassword = System.getenv("githubPassword")
-        val githubRepository = System.getenv("githubRepository")
-
-        if (githubUser != null) {
-            maven {
-                name = "GitHubPackages"
-                url = uri("https://maven.pkg.github.com/$githubRepository")
-                credentials {
-                    username = githubUser
-                    password = githubPassword
-                }
-            }
-        }
-
         val nexusUser: String? = findProperty("REPO_USER") as String? ?: System.getenv("repoUser")
         val nexusPassword: String? = findProperty("REPO_PASSWORD") as String? ?: System.getenv("repoPassword")
 

--- a/src/main/kotlin/fr/ladder/releasr/configuration/PublishingConfiguration.kt
+++ b/src/main/kotlin/fr/ladder/releasr/configuration/PublishingConfiguration.kt
@@ -2,6 +2,7 @@ package fr.ladder.releasr.configuration
 
 import fr.ladder.releasr.ReleasrContext
 import fr.ladder.releasr.VersionType
+import fr.ladder.releasr.extension.GitHubPublicationMode
 import fr.ladder.releasr.extension.ReleasrExtension
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
@@ -10,12 +11,16 @@ import org.gradle.kotlin.dsl.create
 import java.net.URI
 
 fun configureRepositories(publishing: PublishingExtension, releasr: ReleasrExtension) {
-    configureGitHubRepository(publishing)
+    configureGitHubRepository(publishing, releasr)
     configureReleasrRepository(publishing, releasr)
 }
 
-private fun configureGitHubRepository(publishing: PublishingExtension) {
-    if (ReleasrContext.versionType != VersionType.RELEASE)
+private fun configureGitHubRepository(publishing: PublishingExtension, releasr: ReleasrExtension) {
+    val mode = releasr.gitHubPublicationMode.getOrElse(GitHubPublicationMode.NEVER)
+    if(mode == GitHubPublicationMode.NEVER)
+        return
+
+    if(mode == GitHubPublicationMode.ONLY_RELEASE && ReleasrContext.versionType != VersionType.RELEASE)
         return
 
     val githubRepository = System.getenv("githubRepository")

--- a/src/main/kotlin/fr/ladder/releasr/extension/ReleasrExtension.kt
+++ b/src/main/kotlin/fr/ladder/releasr/extension/ReleasrExtension.kt
@@ -9,4 +9,12 @@ interface ReleasrExtension {
     val url: Property<String>
     val username: Property<String>
     val password: Property<String>
+
+    val gitHubPublicationMode: Property<GitHubPublicationMode>
+}
+
+enum class GitHubPublicationMode {
+    ALWAYS,
+    ONLY_RELEASE,
+    NEVER
 }


### PR DESCRIPTION
Publication sur GitHub désormais activante avec l'option `gitHubPublicationMode`.
Valeurs possibles : 
- ALWAYS
- ONLY_RELEASE
- NEVER